### PR TITLE
meta: Add way to specify canonical url for articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The name is synonym of word [Lagom](https://en.wikipedia.org/wiki/Lagom) in Slav
 
 ## DEMO
 
-You can see the [theme in action](http://carambir.in/).
+You can see the [theme in action](http://www.karambir.in/).
 
 ![theme screenshot](https://raw.github.com/karambir/taman/master/screenshot.png)
 
@@ -20,6 +20,7 @@ You can see the [theme in action](http://carambir.in/).
 - social links with FontAwesome4
 - custom favicon and logo urls
 - no custom menu
+- support canonical urls
 
 ## INSTALL
 
@@ -39,6 +40,8 @@ Supports a number of common global variables but patches are welcomed if you nee
 - `DISQUS_SITENAME` set this to your Disqus sitename to enable disqus comments in articles
 
 - `TAGLINE` some text rendered right below the logo
+
+- Use `canonical_url` var in article markdown file to specify original url of article.
 
 - To set custom logo and favicon set following in config:
 

--- a/templates/article.html
+++ b/templates/article.html
@@ -5,6 +5,14 @@
 
 {% block title %}&ndash; {{ article.title }}{% endblock %}
 
+{% block canonical_rel %}
+  {% if article.canonical_url %}
+    <link rel="canonical" href="{{ article.canonical_url }}">
+  {% else %}
+    <link rel="canonical" href="{{ SITEURL }}/{{ article.url }}">
+  {% endif %}
+{% endblock %}
+
 {% block content %}
   <p class="meta">
     {{ article.date|strftime('%d %B %Y') }}
@@ -14,7 +22,7 @@
   </p>
 
   <h1 class="title"><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h1>
-  
+
   <div class="article_text" id="post">
     {{ article.content }}
   </div>
@@ -22,7 +30,7 @@
   <div class="article_meta related">
     <h3>Category: </h3>
     <span><a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</span>
-    
+
     {% if article.tags %}
     <h3>Tags:</h3>
     <span>

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,8 @@
     {% block title %}{% endblock %}
   </title>
 
+  {% block canonical_rel %}{% endblock %}
+
   <link href="//fonts.googleapis.com/css?family=Open+Sans:600,800" rel="stylesheet" type="text/css">
   {% if USER_FAVICON_URL %}
   <link rel="shortcut icon" href="{{ SITEURL }}{{ USER_FAVICON_URL }}">{% else %}
@@ -29,7 +31,7 @@
   <link rel="stylesheet" href="{{ SITEURL }}/{{ ASSET_URL }}">
   {% endassets %}
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-  
+
   {% block head %}
   {% endblock %}
 </head>


### PR DESCRIPTION
Canonical urls are helpful when you have multiple domains serving the
same static page. Services like github and gitlab pages have their own
sub-domains as well as our naked and www sub-domain are serving the same
content. Canonical urls helps search engines identify the real page to
index.

We use canonical_url var from article.md if mentioned or use combination
of SITE_URL and article url